### PR TITLE
Add error handler when open file fail

### DIFF
--- a/tune-temp-sensor-value.cpp
+++ b/tune-temp-sensor-value.cpp
@@ -74,6 +74,7 @@ int main(int argc, char* argv[])
     if(ifile.is_open()){
         while(true)
         {
+            sleep(g_update_period);
             rpm=get_ave_rpm(hwmon_fan_path);
             if (rpm == -1)
             {
@@ -86,7 +87,6 @@ int main(int argc, char* argv[])
             util::SDBusPlus::setProperty(bus, TempSensorService, g_temp_sensor_path,
                                         g_value_intf, "Value", adjust_sensor_val);
             check_sensor_threshold(bus, TempSensorService, adjust_sensor_val);
-            sleep(g_update_period);
         }
         ifile.close();
     }

--- a/tune-temp-sensor-value.cpp
+++ b/tune-temp-sensor-value.cpp
@@ -66,11 +66,7 @@ int main(int argc, char* argv[])
         std::cerr << std::endl;
     }
 
-    while(FanSensorService.empty() || TempSensorService.empty())
-    {
-        FanSensorService = util::SDBusPlus::getService(bus, g_value_intf, g_fan_sensor_path);
-        TempSensorService = util::SDBusPlus::getService(bus, g_value_intf, g_temp_sensor_path);
-    }
+    TempSensorService = util::SDBusPlus::getService(bus, g_value_intf, g_temp_sensor_path);
 
     hwmon_fan_path = find_hwmon_from_OFPath(g_fan_dts_path);
     std::ifstream ifile(find_hwmon_from_OFPath(g_temp_dts_path)+"/temp1_input");
@@ -79,6 +75,10 @@ int main(int argc, char* argv[])
         while(true)
         {
             rpm=get_ave_rpm(hwmon_fan_path);
+            if (rpm == -1)
+            {
+                return -1;
+            }
             ifile.clear();
             ifile.seekg(0);
             ifile >> driver_val;
@@ -90,5 +90,11 @@ int main(int argc, char* argv[])
         }
         ifile.close();
     }
+    else
+    {
+        std::cerr << "Inlet Temperature Sensor Does Not to Open !!!" << std::endl;
+        return -1;
+    }
+    
     return 0;
 }

--- a/tune-temp-sensor-value.cpp
+++ b/tune-temp-sensor-value.cpp
@@ -93,6 +93,7 @@ int main(int argc, char* argv[])
     else
     {
         std::cerr << "Inlet Temperature Sensor Does Not to Open !!!" << std::endl;
+        ifile.close();
         return -1;
     }
     

--- a/tune-temp-sensor-value.cpp
+++ b/tune-temp-sensor-value.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
             rpm=get_ave_rpm(hwmon_fan_path);
             if (rpm == -1)
             {
-                return -1;
+                continue;
             }
             ifile.clear();
             ifile.seekg(0);

--- a/tune-temp-sensor-value.hpp
+++ b/tune-temp-sensor-value.hpp
@@ -103,6 +103,11 @@ static double get_ave_rpm(std::string hwmonfannum)
             rpm += fan_driver_val;
             ifile.close();
         }
+        else
+        {
+            std::cerr << "Fan" + std::to_string(i) + " Sensor Does Not to Open !!!" << std::endl;
+            return -1;
+        }
     }
     rpm /= g_fan_cnt;
     return rpm;

--- a/tune-temp-sensor-value.hpp
+++ b/tune-temp-sensor-value.hpp
@@ -106,6 +106,7 @@ static double get_ave_rpm(std::string hwmonfannum)
         else
         {
             std::cerr << "Fan" + std::to_string(i) + " Sensor Does Not to Open !!!" << std::endl;
+            ifile.close();
             return -1;
         }
     }


### PR DESCRIPTION
1.Add error handler when open file fail such as inlet and fan rpm sensor are opened fail.